### PR TITLE
Add component for performing account operations

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -4,6 +4,8 @@
 
 <main>
   <show-balances></show-balances>
+  <hr />
+  <account-operations></account-operations>
 </main>
 
 <footer>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,11 +1,17 @@
 import {Component} from 'angular2/core';
 import {CORE_DIRECTIVES, FORM_DIRECTIVES } from 'angular2/common';
 
-import {ShowBalancesComponent} from '../components/ShowBalancesComponent';
 import {Bank} from '../bank';
+import {AccountOperationsComponent} from '../components/AccountOperationsComponent';
+import {ShowBalancesComponent} from '../components/ShowBalancesComponent';
 
 @Component({
-  directives: [ CORE_DIRECTIVES, FORM_DIRECTIVES, ShowBalancesComponent ],
+  directives: [
+    CORE_DIRECTIVES,
+    FORM_DIRECTIVES,
+    AccountOperationsComponent,
+    ShowBalancesComponent
+  ],
   pipes: [],
   providers: [ Bank ],
   selector: 'app',

--- a/src/bank.spec.ts
+++ b/src/bank.spec.ts
@@ -11,11 +11,25 @@ import {Bank} from './bank';
 let bank: Bank;
 let accountId = 'account-1';
 
-beforeEachProviders(() => {
-  bank = new Bank().openAccount(accountId);
+describe('clear', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
+  it('should clear all accounts', () => {
+     Bank.clear();
+
+     expect(bank.getAllAccounts().length).toEqual(0);
+  });
 });
 
 describe('openAccount', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should error if account already exists', () => {
     expect(() => bank.openAccount(accountId, 0))
       .toThrowError(`An account with id of \'${accountId}\' already exists.`);
@@ -44,9 +58,22 @@ describe('openAccount', () => {
     expect(account2.id).toEqual('account-2');
     expect(account2.balance).toEqual(initialBalance);
   });
+
+  it('should emit to accountUpdates', () => {
+     spyOn(Bank.accountUpdates, 'emit');
+
+     bank.openAccount('account-2');
+
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith('openAccount: account-2: 0');
+  });
 });
 
 describe('closeAccount', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should error if account does not exist', () => {
     let accountIdDoesNotExist = 'does-not-exist';
 
@@ -67,9 +94,22 @@ describe('closeAccount', () => {
 
     expect(bank.getAllAccounts().length).toEqual(0);
   });
+
+  it('should emit to accountUpdates', () => {
+     spyOn(Bank.accountUpdates, 'emit');
+
+     bank.closeAccount(accountId);
+
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`closeAccount: ${accountId}`);
+  });
 });
 
 describe('deposit', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should error if account does not exist', () => {
     let accountIdDoesNotExist = 'does-not-exist';
 
@@ -114,9 +154,23 @@ describe('deposit', () => {
 
     expect(bank.getBalance(accountId)).toEqual(startingBalance + amount);
   });
+
+  it('should emit to accountUpdates', () => {
+     let amount = 123;
+     spyOn(Bank.accountUpdates, 'emit');
+
+     bank.deposit(accountId, amount);
+
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`deposit: ${accountId}: ${amount}`);
+  });
 });
 
 describe('withdraw', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should error if account does not exist', () => {
     let accountIdDoesNotExist = 'does-not-exist';
 
@@ -172,12 +226,25 @@ describe('withdraw', () => {
 
     expect(bank.getBalance(accountId)).toEqual(startingBalance);
   });
+
+  it('should emit to accountUpdates', () => {
+     let amount = 123;
+     bank.deposit(accountId, amount);
+     spyOn(Bank.accountUpdates, 'emit');
+
+     bank.withdraw(accountId, amount);
+
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`withdraw: ${accountId}: ${amount}`);
+  });
 });
 
 describe('transfer', () => {
   let account2Id = 'account-2';
 
   beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+
     bank.openAccount(account2Id, 0);
   });
 
@@ -260,9 +327,24 @@ describe('transfer', () => {
 
     expect(bank.getBalance(account2Id)).toEqual(amount);
   });
+
+  it('should emit to accountUpdates', () => {
+     let amount = 123;
+     bank.deposit(accountId, amount);
+     spyOn(Bank.accountUpdates, 'emit');
+
+     bank.transfer(accountId, account2Id, amount);
+
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`transfer: ${accountId}: ${amount} => ${account2Id}`);
+  });
 });
 
 describe('getBalance', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should error if account does not exist', () => {
     let accountIdDoesNotExist = 'does-not-exist';
 
@@ -279,6 +361,11 @@ describe('getBalance', () => {
 });
 
 describe('getAllAccounts', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should return the complete collection of accounts', () => {
     bank.openAccount('account-2', 0);
 
@@ -287,6 +374,11 @@ describe('getAllAccounts', () => {
 });
 
 describe('getTotalBankCurrency', () => {
+  beforeEachProviders(() => {
+    Bank.clear();
+    bank = new Bank().openAccount(accountId);
+  });
+
   it('should return a total of all bank held currency', () => {
     let amount1 = 123;
     let amount2 = 234;

--- a/src/bank.spec.ts
+++ b/src/bank.spec.ts
@@ -64,7 +64,11 @@ describe('openAccount', () => {
 
      bank.openAccount('account-2');
 
-     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith('openAccount: account-2: 0');
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith({
+       operation: 'openAccount',
+       accountId: 'account-2',
+       initialBalance: 0
+    });
   });
 });
 
@@ -100,7 +104,10 @@ describe('closeAccount', () => {
 
      bank.closeAccount(accountId);
 
-     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`closeAccount: ${accountId}`);
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith({
+       operation: 'closeAccount',
+       accountId: accountId
+    });
   });
 });
 
@@ -161,7 +168,11 @@ describe('deposit', () => {
 
      bank.deposit(accountId, amount);
 
-     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`deposit: ${accountId}: ${amount}`);
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith({
+       operation: 'deposit',
+       accountId: accountId,
+       amount: amount
+    });
   });
 });
 
@@ -234,7 +245,11 @@ describe('withdraw', () => {
 
      bank.withdraw(accountId, amount);
 
-     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`withdraw: ${accountId}: ${amount}`);
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith({
+       operation: 'withdraw',
+       accountId: accountId,
+       amount: amount
+    });
   });
 });
 
@@ -335,7 +350,12 @@ describe('transfer', () => {
 
      bank.transfer(accountId, account2Id, amount);
 
-     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith(`transfer: ${accountId}: ${amount} => ${account2Id}`);
+     expect(Bank.accountUpdates.emit).toHaveBeenCalledWith({
+       operation: 'transfer',
+       fromAccountId: accountId,
+       toAccountId: account2Id,
+       amount: amount
+    });
   });
 });
 

--- a/src/bank.ts
+++ b/src/bank.ts
@@ -29,7 +29,11 @@ export class Bank {
 
     Bank.accounts.push(new Account(accountId, initialBalance));
 
-    Bank.accountUpdates.emit(`openAccount: ${accountId}: ${initialBalance}`);
+    Bank.accountUpdates.emit({
+      operation: 'openAccount',
+      accountId: accountId,
+      initialBalance: initialBalance
+    });
 
     return this;
   }
@@ -43,7 +47,10 @@ export class Bank {
 
     Bank.accounts = Bank.accounts.filter(x => x.id !== accountId);
 
-    Bank.accountUpdates.emit(`closeAccount: ${accountId}`);
+    Bank.accountUpdates.emit({
+      operation: 'closeAccount',
+      accountId: accountId
+    });
 
     return this;
   }
@@ -67,7 +74,11 @@ export class Bank {
 
     account.balance += amount;
 
-    Bank.accountUpdates.emit(`deposit: ${accountId}: ${amount}`);
+    Bank.accountUpdates.emit({
+      operation: 'deposit',
+      accountId: accountId,
+      amount: amount
+    });
 
     return this;
   }
@@ -97,7 +108,11 @@ export class Bank {
 
     account.balance -= amount;
 
-    Bank.accountUpdates.emit(`withdraw: ${accountId}: ${amount}`);
+    Bank.accountUpdates.emit({
+      operation: 'withdraw',
+      accountId: accountId,
+      amount: amount
+    });
 
     return this;
   }
@@ -129,7 +144,12 @@ export class Bank {
     fromAccount.balance -= amount;
     toAccount.balance += amount;
 
-    Bank.accountUpdates.emit(`transfer: ${fromAccountId}: ${amount} => ${toAccountId}`);
+    Bank.accountUpdates.emit({
+      operation: 'transfer',
+      fromAccountId: fromAccountId,
+      toAccountId: toAccountId,
+      amount: amount
+    });
 
     return this;
   }

--- a/src/components/AccountOperationsComponent.spec.ts
+++ b/src/components/AccountOperationsComponent.spec.ts
@@ -1,0 +1,163 @@
+import {
+  beforeEachProviders,
+  describe,
+  expect,
+  it
+} from 'angular2/testing';
+
+import {AccountOperationsComponent} from './AccountOperationsComponent';
+import {Bank} from '../bank';
+
+let accountId = 'account-1';
+let amount = 123;
+
+let bank: Bank;
+let component: AccountOperationsComponent;
+
+beforeEachProviders(() => {
+  Bank.clear();
+  bank = new Bank();
+  component = new AccountOperationsComponent(bank);
+});
+
+describe('openAccount', () => {
+  it('should throw for missing accountId', () => {
+    component.amount = amount;
+
+    expect(() => component.openAccount())
+      .toThrowError('accountId must be provided.');
+  });
+
+  it('should throw for missing amount', () => {
+    component.accountId = accountId;
+
+    expect(() => component.openAccount())
+      .toThrowError('amount must be provided.');
+  });
+
+  it('should open account', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+    spyOn(bank, 'openAccount');
+
+    component.openAccount();
+
+    expect(bank.openAccount).toHaveBeenCalledWith(accountId, amount);
+  });
+
+  it('should reset amount', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+
+    component.openAccount();
+
+    expect(component.amount).toEqual(0);
+  });
+});
+
+describe('closeAccount', () => {
+  beforeEachProviders(() => {
+    bank.openAccount(accountId);
+  });
+
+  it('should throw for missing accountId', () => {
+    expect(() => component.closeAccount())
+      .toThrowError('accountId must be provided.');
+  });
+
+  it('should close account', () => {
+    component.accountId = accountId;
+    spyOn(bank, 'closeAccount');
+
+    component.closeAccount();
+
+    expect(bank.closeAccount).toHaveBeenCalledWith(accountId);
+  });
+
+  it('should reset amount', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+
+    component.closeAccount();
+
+    expect(component.amount).toEqual(0);
+  });
+});
+
+describe('deposit', () => {
+  beforeEachProviders(() => {
+    bank.openAccount(accountId);
+  });
+
+  it('should throw for missing accountId', () => {
+    component.amount = amount;
+
+    expect(() => component.deposit())
+      .toThrowError('accountId must be provided.');
+  });
+
+  it('should throw for missing amount', () => {
+    component.accountId = accountId;
+
+    expect(() => component.deposit())
+      .toThrowError('amount must be provided.');
+  });
+
+  it('should perform deposit', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+    spyOn(bank, 'deposit');
+
+    component.deposit();
+
+    expect(bank.deposit).toHaveBeenCalledWith(accountId, amount);
+  });
+
+  it('should reset amount', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+
+    component.deposit();
+
+    expect(component.amount).toEqual(0);
+  });
+});
+
+describe('withdraw', () => {
+  beforeEachProviders(() => {
+    bank.openAccount(accountId, amount);
+  });
+
+  it('should throw for missing accountId', () => {
+    component.amount = amount;
+
+    expect(() => component.withdraw())
+      .toThrowError('accountId must be provided.');
+  });
+
+  it('should throw for missing amount', () => {
+    component.accountId = accountId;
+
+    expect(() => component.withdraw())
+      .toThrowError('amount must be provided.');
+  });
+
+  it('should perform withdraw', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+    spyOn(bank, 'withdraw');
+
+    component.withdraw();
+
+    expect(bank.withdraw).toHaveBeenCalledWith(accountId, amount);
+  });
+
+  it('should reset amount', () => {
+    component.accountId = accountId;
+    component.amount = amount;
+
+    component.withdraw();
+
+    expect(component.amount).toEqual(0);
+  });
+});

--- a/src/components/AccountOperationsComponent.ts
+++ b/src/components/AccountOperationsComponent.ts
@@ -1,0 +1,87 @@
+import { Component } from 'angular2/core';
+import { FORM_DIRECTIVES } from 'angular2/common';
+
+import {Account} from '../account';
+import {Bank} from '../bank';
+
+@Component({
+  directives: [ FORM_DIRECTIVES ],
+  providers: [ Bank ],
+  selector: 'account-operations',
+  styles: [`
+  `],
+  template: `
+  <input [(ngModel)]="accountId" type="text" placeholder="accountId" />
+  <input [(ngModel)]="amount" type="number" placeholder="amount" />
+  <button (click)="openAccount()">Open Account</button>
+  <button (click)="closeAccount()">Close Account</button>
+  <button (click)="deposit()">Deposit</button>
+  <button (click)="withdraw()">Withdraw</button>
+  `
+})
+// TODO: Surface errors to user, gray out buttons as they should be / should not be usable
+export class AccountOperationsComponent {
+  public accountId: string;
+  public amount: number;
+
+  private _bank: Bank;
+
+  constructor(bank: Bank) {
+    this._bank = bank;
+  }
+
+  public openAccount() : void {
+    if (!this.accountId) {
+      throw new Error('accountId must be provided.');
+    }
+    if (!this.amount) {
+      throw new Error('amount must be provided.');
+    }
+
+    this._bank.openAccount(this.accountId, this.amount);
+
+    this.resetAmount();
+  }
+
+  public closeAccount() : void {
+    if (!this.accountId) {
+      throw new Error('accountId must be provided.');
+    }
+
+    this._bank.closeAccount(this.accountId);
+
+    this.resetAmount();
+  }
+
+  public deposit() : void {
+    if (!this.accountId) {
+      throw new Error('accountId must be provided.');
+    }
+
+    if (!this.amount) {
+      throw new Error('amount must be provided.');
+    }
+
+    this._bank.deposit(this.accountId, this.amount);
+
+    this.resetAmount();
+  }
+
+  public withdraw() : void {
+    if (!this.accountId) {
+      throw new Error('accountId must be provided.');
+    }
+
+    if (!this.amount) {
+      throw new Error('amount must be provided.');
+    }
+
+    this._bank.withdraw(this.accountId, this.amount);
+
+    this.resetAmount();
+  }
+
+  private resetAmount() : void {
+    this.amount = 0;
+  }
+}

--- a/src/components/ShowBalancesComponent.spec.ts
+++ b/src/components/ShowBalancesComponent.spec.ts
@@ -1,4 +1,5 @@
 import {
+  beforeEachProviders,
   describe,
   expect,
   injectAsync,
@@ -6,7 +7,12 @@ import {
   TestComponentBuilder
 } from 'angular2/testing';
 
+import {Bank} from '../bank';
 import {ShowBalancesComponent} from './ShowBalancesComponent';
+
+beforeEachProviders(() => {
+   Bank.clear();
+});
 
 describe('ShowBalancesComponent', () => {
   it('should be empty to start', injectAsync([TestComponentBuilder], (tcb) => {
@@ -49,8 +55,10 @@ describe('ShowBalancesComponent', () => {
     return tcb.createAsync(ShowBalancesComponent).then((fixture) => {
       fixture.detectChanges();
 
-      fixture.debugElement.componentInstance.bank.openAccount('account-1', 0);
-      fixture.debugElement.componentInstance.bank.openAccount('account-2', 0);
+      fixture.debugElement.componentInstance._bank.openAccount('account-1', 0);
+      fixture.debugElement.componentInstance._bank.openAccount('account-2', 0);
+
+      fixture.debugElement.componentInstance.refreshAccounts();
 
       fixture.detectChanges();
 
@@ -66,7 +74,9 @@ describe('ShowBalancesComponent', () => {
     return tcb.createAsync(ShowBalancesComponent).then((fixture) => {
       fixture.detectChanges();
 
-      fixture.debugElement.componentInstance.bank.openAccount('account-1', 0);
+      fixture.debugElement.componentInstance._bank.openAccount('account-1', 0);
+
+      fixture.debugElement.componentInstance.refreshAccounts();
 
       fixture.detectChanges();
 
@@ -83,7 +93,9 @@ describe('ShowBalancesComponent', () => {
     return tcb.createAsync(ShowBalancesComponent).then((fixture) => {
       fixture.detectChanges();
 
-      fixture.debugElement.componentInstance.bank.openAccount('account-1', 123);
+      fixture.debugElement.componentInstance._bank.openAccount('account-1', 123);
+
+      fixture.debugElement.componentInstance.refreshAccounts();
 
       fixture.detectChanges();
 
@@ -95,4 +107,17 @@ describe('ShowBalancesComponent', () => {
       expect(tdTags[1].innerHTML).toEqual('123');
     });
   }));
+
+  describe('refreshAccounts', () => {
+    it('should refresh accounts', () => {
+      let bank = new Bank();
+      let component = new ShowBalancesComponent(bank);
+
+      bank.openAccount('account-1');
+
+      component.refreshAccounts();
+
+      expect(component.accounts.length).toEqual(1);
+    });
+  });
 });

--- a/src/components/ShowBalancesComponent.ts
+++ b/src/components/ShowBalancesComponent.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component, OnDestroy, OnInit } from 'angular2/core';
 import { CORE_DIRECTIVES } from 'angular2/common';
 
 import {Account} from '../account';
@@ -19,7 +19,7 @@ import {Bank} from '../bank';
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="#account of getAllAccounts()">
+      <tr *ngFor="#account of accounts">
         <td>{{ account.id }}</td>
         <td>{{ account.balance }}</td>
       </tr>
@@ -27,14 +27,26 @@ import {Bank} from '../bank';
   </table>
   `
 })
-export class ShowBalancesComponent {
-  private bank: Bank;
+export class ShowBalancesComponent implements OnInit, OnDestroy {
+  public accounts: Account[];
+
+  private _accountUpdatesSubscription: any;
+  private _bank: Bank;
 
   constructor(bank: Bank) {
-    this.bank = bank;
+    this._bank = bank;
   }
 
-  public getAllAccounts() : Account[] {
-    return this.bank.getAllAccounts();
+  public ngOnInit() {
+    this._accountUpdatesSubscription = Bank.accountUpdates
+      .subscribe(() => this.refreshAccounts());
+  }
+
+  public ngOnDestroy() {
+    this._accountUpdatesSubscription.unsubscribe();
+  }
+
+  public refreshAccounts() : void {
+    this.accounts = this._bank.getAllAccounts();
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "./src/bank.spec.ts",
     "./src/bank.ts",
     "./src/bootstrap.ts",
+    "./src/components/AccountOperationsComponent.spec.ts",
+    "./src/components/AccountOperationsComponent.ts",
     "./src/components/ShowBalancesComponent.spec.ts",
     "./src/components/ShowBalancesComponent.ts",
     "./src/vendor.ts",


### PR DESCRIPTION
This adds **AccountOperationsComponent** along with its associated spec file. Other changes were made to support this component.

Note that the specs for **AccountOperationsComponent** don't interact with the component template.

![image](https://cloud.githubusercontent.com/assets/1012917/11980090/32c3da7e-a966-11e5-8dc9-711d4dc51c65.png)
