### PR TITLE
Disable account operation buttons for invalid states

### DIFF
--- a/src/components/AccountOperationsComponent.spec.ts
+++ b/src/components/AccountOperationsComponent.spec.ts
@@ -2,7 +2,9 @@ import {
   beforeEachProviders,
   describe,
   expect,
-  it
+  injectAsync,
+  it,
+  TestComponentBuilder
 } from 'angular2/testing';
 
 import {AccountOperationsComponent} from './AccountOperationsComponent';
@@ -18,6 +20,287 @@ beforeEachProviders(() => {
   Bank.clear();
   bank = new Bank();
   component = new AccountOperationsComponent(bank);
+});
+
+function getButton(compiled: any, innerText: string) : HTMLButtonElement {
+  // http://stackoverflow.com/a/222847
+  var buttons = [].slice.call(compiled.querySelectorAll('button'))
+    .filter(x => x.innerText === innerText);
+
+  if (buttons.length === 0) {
+    throw new Error(`No buttons were found with innerText: '${innerText}'.`);
+  }
+
+  if (buttons.length > 1) {
+    throw new Error(
+      `More than one button (${buttons.length}) was found with innerText: '${innerText}'.`);
+  }
+
+  return buttons[0];
+};
+
+describe('Open Account button', () => {
+  it('should be disabled when accountId is not provided', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+
+      let openAccountButton = getButton(compiled, 'Open Account');
+
+      expect(openAccountButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if accountId already exists', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId);
+      component.accountId = accountId;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let openAccountButton = getButton(compiled, 'Open Account');
+
+      expect(openAccountButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be enabled when conditions satisfied', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId);
+      component.accountId = 'account-2';
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let openAccountButton = getButton(compiled, 'Open Account');
+
+      expect(openAccountButton.hasAttribute('disabled')).toEqual(false);
+    });
+  }));
+});
+
+describe('Close Account button', () => {
+  it('should be disabled when accountId is not provided', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+
+      let closeAccountButton = getButton(compiled, 'Close Account');
+
+      expect(closeAccountButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if accountId does not exist', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component.accountId = accountId;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let closeAccountButton = getButton(compiled, 'Close Account');
+
+      expect(closeAccountButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if accountId does not have a zero balance', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId, 123);
+      component.accountId = accountId;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let closeAccountButton = getButton(compiled, 'Close Account');
+
+      expect(closeAccountButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be enabled when conditions satisfied', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId);
+      component.accountId = accountId;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let closeAccountButton = getButton(compiled, 'Close Account');
+
+      expect(closeAccountButton.hasAttribute('disabled')).toEqual(false);
+    });
+  }));
+});
+
+describe('Deposit button', () => {
+  it('should be disabled when accountId is not provided', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+
+      let depositButton = getButton(compiled, 'Deposit');
+
+      expect(depositButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if amount is negative', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId);
+      component.accountId = accountId;
+      component.amount = -1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let depositButton = getButton(compiled, 'Deposit');
+
+      expect(depositButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if accountId does not exist', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component.accountId = accountId;
+      component.amount = 1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let depositButton = getButton(compiled, 'Deposit');
+
+      expect(depositButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be enabled when conditions satisfied', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId);
+      component.accountId = accountId;
+      component.amount = 1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let depositButton = getButton(compiled, 'Deposit');
+
+      expect(depositButton.hasAttribute('disabled')).toEqual(false);
+    });
+  }));
+});
+
+describe('Withdraw button', () => {
+  it('should be disabled when accountId is not provided', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+
+      let withdrawButton = getButton(compiled, 'Withdraw');
+
+      expect(withdrawButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if accountId does not exist', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component.accountId = accountId;
+      component.amount = 1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let withdrawButton = getButton(compiled, 'Withdraw');
+
+      expect(withdrawButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if amount is negative', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId, 1);
+      component.accountId = accountId;
+      component.amount = -1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let withdrawButton = getButton(compiled, 'Withdraw');
+
+      expect(withdrawButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be disabled if account does not have enough funds to complete withdraw', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId);
+      component.accountId = accountId;
+      component.amount = 1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let withdrawButton = getButton(compiled, 'Withdraw');
+
+      expect(withdrawButton.hasAttribute('disabled')).toEqual(true);
+    });
+  }));
+
+  it('should be enabled when conditions satisfied', injectAsync([TestComponentBuilder], (tcb) => {
+    return tcb.createAsync(AccountOperationsComponent).then((fixture) => {
+      fixture.detectChanges();
+
+      let component = fixture.debugElement.componentInstance;
+      component._bank.openAccount(accountId, 1);
+      component.accountId = accountId;
+      component.amount = 1;
+
+      fixture.detectChanges();
+
+      let compiled = fixture.debugElement.nativeElement;
+      let withdrawButton = getButton(compiled, 'Withdraw');
+
+      expect(withdrawButton.hasAttribute('disabled')).toEqual(false);
+    });
+  }));
 });
 
 describe('openAccount', () => {

--- a/src/components/AccountOperationsComponent.ts
+++ b/src/components/AccountOperationsComponent.ts
@@ -13,16 +13,78 @@ import {Bank} from '../bank';
   template: `
   <input [(ngModel)]="accountId" type="text" placeholder="accountId" />
   <input [(ngModel)]="amount" type="number" placeholder="amount" />
-  <button (click)="openAccount()">Open Account</button>
-  <button (click)="closeAccount()">Close Account</button>
-  <button (click)="deposit()">Deposit</button>
-  <button (click)="withdraw()">Withdraw</button>
+  <button (click)="openAccount()" [disabled]="openAccountProhibited">Open Account</button>
+  <button (click)="closeAccount()" [disabled]="closeAccountProhibited">Close Account</button>
+  <button (click)="deposit()" [disabled]="depositProhibited">Deposit</button>
+  <button (click)="withdraw()" [disabled]="withdrawProhibited">Withdraw</button>
   `
 })
-// TODO: Surface errors to user, gray out buttons as they should be / should not be usable
+// TODO: Surface any errors to the user
 export class AccountOperationsComponent {
   public accountId: string;
-  public amount: number;
+  public amount: number = 0;
+
+  public get openAccountProhibited() {
+    if (!this.accountId) {
+      return true;
+    }
+
+    let anyExistingAccount = this._bank
+      .getAllAccounts()
+      .some(x => x.id === this.accountId);
+
+    return anyExistingAccount;
+  };
+
+  public get closeAccountProhibited() {
+    if (!this.accountId) {
+      return true;
+    }
+
+    let anyExistingZeroBalanceAccount = this._bank
+      .getAllAccounts()
+      .some(x => x.id === this.accountId && x.balance === 0);
+
+    return !anyExistingZeroBalanceAccount;
+  };
+
+  public get depositProhibited() {
+    if (!this.accountId) {
+      return true;
+    }
+
+    if (this.amount < 0) {
+      return true;
+    }
+
+    let anyExistingAccount = this._bank
+      .getAllAccounts()
+      .some(x => x.id === this.accountId);
+
+    return !anyExistingAccount;
+  };
+
+  public get withdrawProhibited() {
+    if (!this.accountId) {
+      return true;
+    }
+
+    if (this.amount < 0) {
+      return true;
+    }
+
+    let existingAccounts = this._bank
+      .getAllAccounts()
+      .filter(x => x.id === this.accountId);
+
+    if (existingAccounts.length === 0) {
+      return true;
+    }
+
+    let existingAccount = existingAccounts[0];
+
+    return existingAccount.balance < this.amount;
+  };
 
   private _bank: Bank;
 


### PR DESCRIPTION
If the **accountId** and **amount** values specified are not valid for pressing the buttons based on the state of the bank accounts and other validation, disable the buttons to prevent them from being clicked.

This also expresses that the operation is unable to be performed using the current **accountId** and **amount** values.
