### PR TITLE
Add alerts for unhandled exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/ritterim/angular2-bank",
   "dependencies": {
+    "alerts": "^0.1.3",
     "angular2": "2.0.0-beta.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",

--- a/src/UserNotifyingExceptionHandler.ts
+++ b/src/UserNotifyingExceptionHandler.ts
@@ -1,0 +1,35 @@
+import { ExceptionHandler } from 'angular2/core';
+import { print } from 'angular2/src/facade/lang';
+let alert = require('alerts');
+
+export class UserNotifyingExceptionHandler extends ExceptionHandler {
+  private alertTimeout = 5000;
+  private transitionTime = 200; // Matches the css transition time
+
+  constructor() {
+    super(new PrintLogger(), /* _rethrowException: */ true);
+  }
+
+  call(error, stackTrace = null, reason = null) {
+    let splitErrorMessage = error.message.split('\n');
+    let errorMessageToDisplay = `${splitErrorMessage[0]}<br />${splitErrorMessage[1]}`;
+
+    alert(errorMessageToDisplay, {
+      timeout: this.alertTimeout,
+      transitionTime: this.transitionTime
+    });
+
+    // Call the parent behavior (remove in production?)
+    super.call(error, stackTrace, reason);
+  }
+}
+
+/* tslint:disable:max-line-length no-empty */
+// https://github.com/angular/angular/blob/7ae23adaff2990cf6022af9792c449730d451d1d/modules/angular2/src/platform/worker_app_common.ts#L28-L33
+class PrintLogger {
+  log = print;
+  logError = print;
+  logGroup = print;
+  logGroupEnd() {}
+}
+/* tslint:enable */

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -9,6 +9,9 @@ import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
 // include for production builds
 // import {enableProdMode} from 'angular2/core';
 
+import {ExceptionHandler, provide} from 'angular2/core';
+import {UserNotifyingExceptionHandler} from './UserNotifyingExceptionHandler';
+
 /*
  * App Component
  * our top level component that holds all of our components
@@ -22,6 +25,9 @@ import {App} from './app/app';
 // enableProdMode() // include for production builds
 function main() {
   return bootstrap(App, [
+    // This paves over the default ExceptionHandler.
+    provide(ExceptionHandler, {useClass: UserNotifyingExceptionHandler}),
+
     // These are dependencies of our App
     HTTP_PROVIDERS,
     ROUTER_PROVIDERS,

--- a/src/components/AccountOperationsComponent.ts
+++ b/src/components/AccountOperationsComponent.ts
@@ -21,7 +21,6 @@ import {Bank} from '../bank';
   `],
   template: require('./AccountOperationsComponent.html')
 })
-// TODO: Surface any errors to the user
 export class AccountOperationsComponent {
   public accountId: string;
   public amount: number;

--- a/src/public/css/.gitkeep
+++ b/src/public/css/.gitkeep
@@ -1,1 +1,0 @@
-@AngularClass

--- a/src/public/css/alerts.css
+++ b/src/public/css/alerts.css
@@ -1,0 +1,25 @@
+/* Adapted from CSS posted at https://www.npmjs.com/package/alerts */
+.alerts {
+	position: fixed;
+	z-index: 10000;
+	width: 30em;
+	top: 1em;
+	right: 1em;
+}
+
+.alerts > div {
+	padding: .8em;
+	margin-bottom: .4em;
+	background-color: lightpink;
+	cursor: default;
+  transition: opacity .2s;
+}
+
+.alerts > .alert,
+.alerts > .alert-dismiss {
+	opacity: 0;
+}
+
+.alerts > .alert-show {
+	opacity: 1;
+}

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -8,6 +8,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Angular2 Bank">
 
+  <link rel="stylesheet" href="css/alerts.css">
+
   <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.indigo-pink.min.css">
   <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
Resolves #23.
## 

This adds a notification for unhandled exceptions that are user viewable. This may or may not be a feature you'd want to disable in production, depending on the use case.

It isn't perfect, in that the console output is changed from `error` coloring to a regular `log` coloring for a bit.

The screenshot below was generated with the help of this diff:

``` diff
diff --git a/src/components/AccountOperationsComponent.ts b/src/components/AccountOperationsComponent.ts
index 9a0a832..6887dc4 100644
--- a/src/components/AccountOperationsComponent.ts
+++ b/src/components/AccountOperationsComponent.ts
@@ -133,6 +133,8 @@ export class AccountOperationsComponent {
   }

   public openAccount() : void {
+    throw new Error('test error!');
+
     if (!this.accountId) {
       throw new Error('accountId must be provided.');
     }
```

![image](https://cloud.githubusercontent.com/assets/1012917/12361942/03e65692-bb8f-11e5-9c01-d3e9a1f2d3b8.png)
